### PR TITLE
Fix typos and improve Sellmeier formula

### DIFF
--- a/PyOptik/material/base_class.py
+++ b/PyOptik/material/base_class.py
@@ -80,7 +80,7 @@ class BaseMaterial:
         def wrapper(self, wavelength: Quantity = None, *args, **kwargs):
             if wavelength is None:
                 if self.wavelength_bound is None:
-                    raise ValueError('Wavelenght must be provided for computation.')
+                    raise ValueError('Wavelength must be provided for computation.')
                 wavelength = numpy.linspace(self.wavelength_bound[0].magnitude, self.wavelength_bound[1].magnitude, 100) * self.wavelength_bound.units
 
             import PyOptik.units

--- a/PyOptik/material/sellmeier_class.py
+++ b/PyOptik/material/sellmeier_class.py
@@ -133,7 +133,7 @@ class SellmeierMaterial(BaseMaterial):
             case 5:  # Formula 5 computation (extended Sellmeier)
                 n = 1 + self.coefficients[0]
                 for (B, C) in zipped_coefficients:
-                    n = B * wavelength.to(micrometer).magnitude**C
+                    n += B * wavelength.to(micrometer).magnitude**C
 
             case 6:
                 n = 1 + self.coefficients[0]

--- a/PyOptik/material/tabulated_class.py
+++ b/PyOptik/material/tabulated_class.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 from PyOptik.units import Quantity, micrometer, meter
 
 
-
 class TabulatedMaterial(BaseMaterial):
     """
     Class representing a material with tabulated refractive index (n) and absorption (k) values.

--- a/PyOptik/material/tabulated_class.py
+++ b/PyOptik/material/tabulated_class.py
@@ -134,10 +134,6 @@ class TabulatedMaterial(BaseMaterial):
         ----------
         wavelength : Optional[Quantity]
             The range of wavelengths to plot, in micrometers. If not provided, the entire tabulated wavelength range is used.
-        title : str, optional
-            Title of the plot.
-        grid : bool, optional
-            Whether to show grid lines on the plot.
 
         Raises
         ------

--- a/PyOptik/material_bank.py
+++ b/PyOptik/material_bank.py
@@ -327,12 +327,10 @@ class _MaterialBank():
             If True, removes existing files before downloading new ones.
         """
         AVAILABLE_LIBRARIES = set([os.path.splitext(f)[0] for f in os.listdir(libraries_path) if f.endswith('.yml')])
-
         libraries_to_download = AVAILABLE_LIBRARIES if library == 'all' else set(numpy.atleast_1d(library))
 
         # Ensure the requested library exists
         assert libraries_to_download.issubset(AVAILABLE_LIBRARIES), f"Library value should be in {AVAILABLE_LIBRARIES}"
-
 
         repertoire_file = libraries_path / 'repertoire.yml'
         with open(repertoire_file, 'r') as file:

--- a/PyOptik/material_bank.py
+++ b/PyOptik/material_bank.py
@@ -127,8 +127,10 @@ class _MaterialBank():
         cls.use_sellmeier = use_sellmeier
 
     def _list_materials(self, material_type: MaterialType) -> List[str]:
-        """create_sellmeier_file
-        Helper method to list materials of a specific type.
+        """Return the list of materials of a given type.
+
+        This is a small helper used internally by the various ``*.materials``
+        properties to gather the available YAML files in the data directory.
 
         Parameters
         ----------
@@ -181,12 +183,10 @@ class _MaterialBank():
         """
         return self.sellmeier + self.tabulated
 
-    def print_available(cls) -> None:
-        """
-        Prints out all the available Sellmeier and Tabulated materials in a tabulated format.
-        """
-        sellmeier_materials = cls.sellmeier
-        tabulated_materials = cls.tabulated
+    def print_available(self) -> None:
+        """Display all available materials in a nicely formatted table."""
+        sellmeier_materials = self.sellmeier
+        tabulated_materials = self.tabulated
 
         # Create data for the table
         table_data = []
@@ -428,19 +428,18 @@ class _MaterialBank():
             data: List[Tuple[float, float, float]],
             reference: Optional[str] = None,
             comments: Optional[str] = None) -> None:
-        """
-        Creates a YAML file with tabulated nk data in the correct format.
+        """Create a YAML file describing tabulated :math:`n` and :math:`k` values.
 
         Parameters
         ----------
-        filename : str)
-            The name of the file to create (without the extension).
-        data : List[Tuple[float, float, float]])
-            The tabulated nk data.
-        reference : Optional[str])
-            A reference for the material data.
-        comments : Optional[str])
-            Additional comments about the material.
+        filename : str
+            Name of the file to create (without extension).
+        data : list[tuple[float, float, float]]
+            Sequence of ``(wavelength, n, k)`` triplets in micrometers.
+        reference : Optional[str], optional
+            Bibliographic reference associated with the dataset.
+        comments : Optional[str], optional
+            Additional free-form comments to store in the YAML file.
         """
         reference = 'None' if reference is None else reference
 

--- a/PyOptik/utils.py
+++ b/PyOptik/utils.py
@@ -10,8 +10,29 @@ logging.basicConfig(
 )
 
 def download_yml_file(url: str, filename: str, location: MaterialType) -> None:
-    """
-    Downloads a .yml file from a specified URL and saves it locally.
+    """Download a YAML file and store it in the local data directory.
+
+    Parameters
+    ----------
+    url : str
+        The fully qualified URL to download.
+    filename : str
+        Name of the file (without extension) under which the data will be saved.
+    location : MaterialType
+        Destination folder identifier. Use ``MaterialType.SELLMEIER`` for
+        Sellmeier materials or ``MaterialType.TABULATED`` for tabulated ones.
+
+    Raises
+    ------
+    ValueError
+        If ``location`` is not a supported :class:`~PyOptik.material_type.MaterialType`.
+    requests.exceptions.Timeout
+        If the request times out after 10 seconds.
+    requests.exceptions.HTTPError
+        If the server returns an HTTP error status.
+    Exception
+        Propagates any unexpected error that occurred during download or file
+        writing.
     """
     match location:
         case MaterialType.SELLMEIER:

--- a/PyOptik/utils.py
+++ b/PyOptik/utils.py
@@ -9,6 +9,7 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
 )
 
+
 def download_yml_file(url: str, filename: str, location: MaterialType) -> None:
     """Download a YAML file and store it in the local data directory.
 
@@ -41,7 +42,6 @@ def download_yml_file(url: str, filename: str, location: MaterialType) -> None:
             file_path = tabulated_data_path / f"{filename}.yml"
         case _:
             raise ValueError(f"Location [{location}] is invalid, it can be either MaterialType.SELLMEIER or MaterialType.TABULATED")
-
 
     logging.info(f"Starting download of {url!r} → {file_path!s}")
     try:

--- a/tests/test_base_material.py
+++ b/tests/test_base_material.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+
+from PyOptik.material.base_class import BaseMaterial
+from PyOptik.units import micrometer, meter, Quantity
+
+
+class DummyMaterial(BaseMaterial):
+    def __init__(self, bounds=None):
+        self.filename = "dummy"
+        self.wavelength_bound = bounds
+
+    @BaseMaterial.ensure_units
+    def echo(self, wavelength: Quantity = None) -> Quantity:
+        return wavelength
+
+
+def test_ensure_units_provides_default_range():
+    bounds = np.array([0.4, 0.7]) * micrometer
+    mat = DummyMaterial(bounds=bounds)
+
+    result = mat.echo()
+
+    assert isinstance(result, Quantity)
+    assert len(result) == 100
+    assert np.isclose(result.magnitude[0], 0.4)
+    assert np.isclose(result.magnitude[-1], 0.7)
+    assert result.units == micrometer
+
+
+def test_ensure_units_converts_float():
+    bounds = np.array([0.4, 0.7]) * micrometer
+    mat = DummyMaterial(bounds=bounds)
+
+    result = mat.echo(0.5)
+
+    assert isinstance(result, Quantity)
+    assert np.isclose(result.magnitude, 0.5)
+    assert result.units == meter  # ensure_units converts to meters
+
+
+def test_ensure_units_no_bounds_error():
+    mat = DummyMaterial(bounds=None)
+
+    with pytest.raises(ValueError, match="Wavelength must be provided"):
+        mat.echo(None)
+

--- a/tests/test_sellmeier.py
+++ b/tests/test_sellmeier.py
@@ -129,6 +129,20 @@ def test_compute_refractive_index_inputs():
     assert isinstance(refractive_index, np.ndarray), f"Refractive index [{refractive_index}] should return an array when wavelength [{wavelength}] input is an array"
 
 
+def test_formula_type_5_accumulation():
+    """Ensure formula type 5 accumulates all terms when computing the index."""
+    material = Material('acetone')
+
+    wl = 0.5 * micrometer
+    calculated = material.compute_refractive_index(wl)
+
+    expected = 1 + material.coefficients[0]
+    for B, C in zip(material.coefficients[1::2], material.coefficients[2::2]):
+        expected += B * wl.to(micrometer).magnitude ** C
+
+    assert np.isclose(calculated, expected)
+
+
 def test_invalid_formula_type():
     """Test handling of unsupported material types."""
     with pytest.raises(FileNotFoundError):

--- a/tests/test_usual_materials.py
+++ b/tests/test_usual_materials.py
@@ -41,6 +41,23 @@ def test_material_bank_filter():
     MaterialBank.set_filter(use_sellmeier=True, use_tabulated=True)
 
 
+def test_set_filter_invalid():
+    with pytest.raises(ValueError):
+        MaterialBank.set_filter(use_sellmeier=False, use_tabulated=False)
+
+
+def test_getattr_and_get():
+    mat = MaterialBank.water
+    same = MaterialBank.get("water")
+    assert mat.filename == "water"
+    assert same.filename == mat.filename
+
+
+def test_get_unknown_material():
+    with pytest.raises(AttributeError):
+        MaterialBank.get("unknown_material")
+
+
 def test_fail_wrong_clean():
     with pytest.raises(ValueError):
         MaterialBank.clean_data_files(regex='test*', location='invalid')

--- a/tests/test_usual_materials.py
+++ b/tests/test_usual_materials.py
@@ -58,6 +58,14 @@ def test_get_unknown_material():
         MaterialBank.get("unknown_material")
 
 
+def test_print_available_output(capsys):
+    """Ensure ``print_available`` prints a table listing materials."""
+    MaterialBank.print_available()
+    captured = capsys.readouterr()
+    assert "Sellmeier Materials" in captured.out
+    assert "Tabulated Materials" in captured.out
+
+
 def test_fail_wrong_clean():
     with pytest.raises(ValueError):
         MaterialBank.clean_data_files(regex='test*', location='invalid')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from unittest.mock import patch
+
 from PyOptik import MaterialBank, MaterialType
 from PyOptik.utils import download_yml_file
+from PyOptik.directories import sellmeier_data_path, tabulated_data_path
 
 MaterialBank.set_filter(use_sellmeier=True, use_tabulated=True)
 
@@ -52,13 +55,44 @@ def test_fail_add_custom():
         )
 
 
-def test_build_library():
-    """
-    Test the creation of the default library. Ensures that the default library
-    is built without errors.
-    """
-    pass
-    # MaterialBank.build_library('minimal', remove_previous=True)
+
+
+def _dummy_download(url: str, filename: str, location: MaterialType) -> None:
+    """Create an empty file to mimic a download."""
+    match location:
+        case MaterialType.SELLMEIER:
+            path = sellmeier_data_path / f"{filename}.yml"
+        case MaterialType.TABULATED:
+            path = tabulated_data_path / f"{filename}.yml"
+        case _:
+            raise ValueError
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("test")
+
+
+@patch("PyOptik.material_bank.download_yml_file", side_effect=_dummy_download)
+def test_build_library(mock_download):
+    """Ensure the minimal library is built and files are created."""
+    MaterialBank.build_library("minimal", remove_previous=True)
+
+    expected = [
+        sellmeier_data_path / "argon.yml",
+        sellmeier_data_path / "air.yml",
+        sellmeier_data_path / "water.yml",
+        sellmeier_data_path / "soda_lime_glass.yml",
+        tabulated_data_path / "zinc.yml",
+        tabulated_data_path / "silicon.yml",
+    ]
+
+    for path in expected:
+        assert path.exists(), f"{path.name} should be created"
+
+    assert mock_download.call_count == len(expected)
+
+    MaterialBank.clean_data_files(regex=".*", location="any")
+
+    for path in expected:
+        assert not path.exists()
 
 
 def test_remove_item():


### PR DESCRIPTION
## Summary
- fix typo in `BaseMaterial` error message
- correctly accumulate terms in Sellmeier formula type 5
- clean up `TabulatedMaterial.plot` docstring
- add regression test for Sellmeier formula 5
- implement functional test for building minimal library
- extend test suite with extra assertions and BaseMaterial unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871411ce878832c9289d07990aa7098