### PR TITLE
Add more unit tests

### DIFF
--- a/PyOptik/directories.py
+++ b/PyOptik/directories.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""Convenience paths used throughout the :mod:`PyOptik` package.
+
+This module exposes commonly referenced directories such as the project
+root, documentation and data folders.  It is imported by other modules to
+construct absolute paths in a centralised manner and therefore simplifies
+file handling across the code base.
+"""
+
 from pathlib import Path
 import PyOptik
 

--- a/PyOptik/material/base_class.py
+++ b/PyOptik/material/base_class.py
@@ -64,18 +64,18 @@ class BaseMaterial:
                 )
 
     def ensure_units(func) -> Callable:
-        """
-        Decorator to ensure that the wavelength parameter has the correct units.
+        """Decorator ensuring the wavelength argument carries units.
 
         Parameters
         ----------
         func : Callable
-            The function to wrap.
+            Function that expects a wavelength :class:`~PyOptik.units.Quantity`.
 
         Returns
         -------
         Callable
-            The wrapped function that ensures wavelength is a Quantity in meters.
+            Wrapped version of ``func`` that accepts numerical wavelengths and
+            converts them to metre-based :class:`~PyOptik.units.Quantity` objects.
         """
         def wrapper(self, wavelength: Quantity = None, *args, **kwargs):
             if wavelength is None:

--- a/PyOptik/material_bank.py
+++ b/PyOptik/material_bank.py
@@ -127,8 +127,7 @@ class _MaterialBank():
         cls.use_sellmeier = use_sellmeier
 
     def _list_materials(self, material_type: MaterialType) -> List[str]:
-        """create_sellmeier_file
-        Helper method to list materials of a specific type.
+        """Return available material names for a given type.
 
         Parameters
         ----------
@@ -182,8 +181,11 @@ class _MaterialBank():
         return self.sellmeier + self.tabulated
 
     def print_available(cls) -> None:
-        """
-        Prints out all the available Sellmeier and Tabulated materials in a tabulated format.
+        """Display all available materials in a table.
+
+        The method lists both Sellmeier and tabulated materials currently
+        stored in the local database and prints them in two columns using
+        :func:`tabulate.tabulate`.
         """
         sellmeier_materials = cls.sellmeier
         tabulated_materials = cls.tabulated
@@ -370,25 +372,29 @@ class _MaterialBank():
             reference: Optional[str] = None,
             comments: Optional[str] = None,
             specs: Optional[dict] = None) -> None:
-        """
-        Creates a YAML file with custom Sellmeier coefficients in the correct format.
+        """Create a custom Sellmeier material definition.
 
         Parameters
         ----------
         filename : str
-            The name of the file to create (without the extension).
+            Name of the output file without extension.
         formula_type : int
-            The type of Sellmeier formula.
-        coefficients :  list[float]
-            A list of coefficients for the Sellmeier equation.
-        wavelength_range : Tuple[float, float]
-            The range of wavelengths, in micrometers.
-        reference : str
-            A reference for the material data.
-        comments : Optional[str]
-            Additional comments about the material.
-        specs : Optional[dict]
-            Additional specifications, such as temperature and whether the wavelength is in a vacuum.
+            Identifier of the Sellmeier formula to use.
+        coefficients : list[float]
+            Coefficients of the selected Sellmeier equation.
+        wavelength_range : tuple[float, float], optional
+            Minimum and maximum wavelength in micrometers.
+        reference : str, optional
+            Reference or citation for the data.
+        comments : str, optional
+            Additional comments stored in the file.
+        specs : dict, optional
+            Extra specifications such as temperature or vacuum information.
+
+        Notes
+        -----
+        The YAML file is written to ``data/sellmeier`` within the package
+        directory.
         """
         reference = 'None' if reference is None else reference
 
@@ -428,19 +434,23 @@ class _MaterialBank():
             data: List[Tuple[float, float, float]],
             reference: Optional[str] = None,
             comments: Optional[str] = None) -> None:
-        """
-        Creates a YAML file with tabulated nk data in the correct format.
+        """Create a tabulated ``n``/``k`` material definition.
 
         Parameters
         ----------
-        filename : str)
-            The name of the file to create (without the extension).
-        data : List[Tuple[float, float, float]])
-            The tabulated nk data.
-        reference : Optional[str])
-            A reference for the material data.
-        comments : Optional[str])
-            Additional comments about the material.
+        filename : str
+            Name of the output file without extension.
+        data : list[tuple[float, float, float]]
+            Sequence of ``(wavelength, n, k)`` tuples.
+        reference : str, optional
+            Reference or citation for the data.
+        comments : str, optional
+            Additional comments stored in the file.
+
+        Notes
+        -----
+        The YAML file is written to ``data/tabulated`` within the package
+        directory.
         """
         reference = 'None' if reference is None else reference
 

--- a/PyOptik/material_type.py
+++ b/PyOptik/material_type.py
@@ -5,5 +5,7 @@ from enum import Enum
 
 
 class MaterialType(Enum):
+    """Enumeration of material data representations."""
+
     SELLMEIER = "sellmeier"
     TABULATED = "tabulated"

--- a/PyOptik/units.py
+++ b/PyOptik/units.py
@@ -14,15 +14,19 @@ SCALES = ['nano', 'micro', 'milli', '', 'kilo', 'mega']
 
 
 def initialize_registry(ureg: Optional[pint.UnitRegistry] = None) -> None:
-    """
-    Initialize and set up a unit registry. This function also leaks
-    the units into the global namespace for easy access throughout
-    the module.
+    """Initialise the unit registry used by :mod:`PyOptik`.
 
     Parameters
     ----------
-    ureg: Optional[pint.UnitRegistry]
-        A UnitRegistry object to use. If None, the default PintType.ureg will be used.
+    ureg : Optional[pint.UnitRegistry], optional
+        A preconfigured :class:`~pint.UnitRegistry` instance. When ``None`` (the
+        default) a new registry is created and configured.
+
+    Notes
+    -----
+    The registry is configured for matplotlib integration and a number of unit
+    shortcuts (``nano``/``micro``/``milli``/... ``meter``) as well as commonly
+    used units are leaked into the module's global namespace for convenience.
     """
 
     # If no unit registry is provided, use the default

--- a/PyOptik/utils.py
+++ b/PyOptik/utils.py
@@ -10,8 +10,28 @@ logging.basicConfig(
 )
 
 def download_yml_file(url: str, filename: str, location: MaterialType) -> None:
-    """
-    Downloads a .yml file from a specified URL and saves it locally.
+    """Download and store a material YAML file.
+
+    Parameters
+    ----------
+    url : str
+        Direct link to the YAML file to download.
+    filename : str
+        Name (without extension) used when saving the file locally.
+    location : MaterialType
+        Target directory; either ``MaterialType.SELLMEIER`` or
+        ``MaterialType.TABULATED``.
+
+    Raises
+    ------
+    ValueError
+        If ``location`` does not correspond to a known directory.
+    requests.exceptions.Timeout
+        If the download does not finish within 10 seconds.
+    requests.exceptions.HTTPError
+        If the server returns an HTTP error code.
+    Exception
+        For any other unexpected error during download or write.
     """
     match location:
         case MaterialType.SELLMEIER:

--- a/tests/test_base_material_decorator.py
+++ b/tests/test_base_material_decorator.py
@@ -1,0 +1,35 @@
+import numpy
+import pytest
+from PyOptik.material.base_class import BaseMaterial
+from PyOptik.units import meter, Quantity
+
+
+class Dummy(BaseMaterial):
+    def __init__(self):
+        self.filename = 'dummy'
+        self.wavelength_bound = numpy.array([1.0, 2.0]) * meter
+
+    @BaseMaterial.ensure_units
+    def identity(self, wavelength: Quantity) -> Quantity:
+        return wavelength
+
+def test_ensure_units_numeric():
+    dummy = Dummy()
+    out = dummy.identity(1.5)
+    assert isinstance(out, Quantity)
+    assert out.units == meter
+
+
+def test_ensure_units_quantity():
+    dummy = Dummy()
+    wl = 1.6 * meter
+    out = dummy.identity(wl)
+    assert out == wl
+
+
+def test_ensure_units_default():
+    dummy = Dummy()
+    out = dummy.identity()
+    assert len(out) == 100
+    assert out.units == meter
+

--- a/tests/test_material_bank_extra.py
+++ b/tests/test_material_bank_extra.py
@@ -1,0 +1,32 @@
+import pytest
+from pathlib import Path
+
+from PyOptik import MaterialBank
+from PyOptik.material_type import MaterialType
+
+
+
+
+def test_set_filter_invalid():
+    with pytest.raises(ValueError):
+        MaterialBank.set_filter(use_tabulated=False, use_sellmeier=False)
+    # restore default
+    MaterialBank.set_filter(use_tabulated=True, use_sellmeier=True)
+
+
+def test_list_materials(monkeypatch, tmp_path):
+    tmp_sell = tmp_path / "sellmeier"
+    tmp_tab = tmp_path / "tabulated"
+    tmp_sell.mkdir()
+    tmp_tab.mkdir()
+    (tmp_sell / "mat1.yml").write_text("test")
+    (tmp_tab / "mat2.yml").write_text("test")
+
+    with monkeypatch.context() as m:
+        m.setattr("PyOptik.material_bank.data_path", tmp_path)
+        sell_list = MaterialBank._list_materials(MaterialType.SELLMEIER)
+        tab_list = MaterialBank._list_materials(MaterialType.TABULATED)
+
+    assert sell_list == ["mat1"]
+    assert tab_list == ["mat2"]
+

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from unittest.mock import Mock
+import pytest
+import requests
+
+from PyOptik.utils import download_yml_file
+from PyOptik.material_type import MaterialType
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, content=b"ok"):
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"status {self.status_code}")
+
+def test_download_success(monkeypatch, tmp_path):
+    monkeypatch.setattr('PyOptik.utils.sellmeier_data_path', tmp_path)
+    resp = DummyResponse()
+    monkeypatch.setattr(requests, 'get', lambda *a, **k: resp)
+    download_yml_file('http://foo', 'file', MaterialType.SELLMEIER)
+    assert (tmp_path / 'file.yml').read_bytes() == resp.content
+
+
+def test_download_http_error(monkeypatch, tmp_path):
+    monkeypatch.setattr('PyOptik.utils.sellmeier_data_path', tmp_path)
+    resp = DummyResponse(status_code=404)
+    monkeypatch.setattr(requests, 'get', lambda *a, **k: resp)
+    with pytest.raises(requests.exceptions.HTTPError):
+        download_yml_file('http://foo', 'file', MaterialType.SELLMEIER)
+
+
+def test_download_timeout(monkeypatch):
+    monkeypatch.setattr(requests, 'get', Mock(side_effect=requests.exceptions.Timeout))
+    with pytest.raises(requests.exceptions.Timeout):
+        download_yml_file('http://foo', 'file', MaterialType.SELLMEIER)
+


### PR DESCRIPTION
## Summary
- expand unit test coverage across utilities and base classes
- add tests for MaterialBank filters and material listing
- verify BaseMaterial.ensure_units decorator behavior
- add network error tests for `download_yml_file`

## Testing
- `pytest -q tests/test_sellmeier.py tests/test_tabulated.py tests/test_usual_materials.py tests/test_material_bank_extra.py tests/test_base_material_decorator.py tests/test_utils_extra.py tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68718c9f74c4832cbe179ed15360c104