### PR TITLE
Add group index utilities and tests

### DIFF
--- a/PyOptik/material/base_class.py
+++ b/PyOptik/material/base_class.py
@@ -3,6 +3,7 @@
 
 from typing import Callable
 from PyOptik.units import Quantity, meter
+from PyOptik.units import ureg
 import numpy
 import warnings
 
@@ -88,3 +89,19 @@ class BaseMaterial:
                 wavelength = wavelength * meter
             return func(self, wavelength, *args, **kwargs)
         return wrapper
+
+    @ensure_units
+    def compute_group_index(self, wavelength: Quantity) -> Quantity:
+        """Calculate the group refractive index n_g(\u03bb)."""
+        delta = 1e-9 * meter
+        n = self.compute_refractive_index(wavelength)
+        n_plus = self.compute_refractive_index(wavelength + delta)
+        dn_dlambda = (n_plus - n) / delta
+        return n - wavelength * dn_dlambda
+
+    @ensure_units
+    def compute_group_velocity(self, wavelength: Quantity) -> Quantity:
+        """Return the group velocity v_g(\u03bb)."""
+        ng = self.compute_group_index(wavelength)
+        c = 299792458 * meter / ureg.second
+        return c / ng

--- a/PyOptik/units.py
+++ b/PyOptik/units.py
@@ -6,7 +6,8 @@ pint.set_application_registry(ureg)
 
 # Define a list of base units to scale
 BASE_UNITS = [
-    'meter'
+    'meter',
+    'second'
 ]
 
 # Define prefixes for scaling units

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Features
 - **Simulation Ready**: Ideal for light-matter interaction simulations, particularly in optics and photonics.
 - **Simple API**: Easy-to-use API that integrates well with other Python libraries.
 - **Open Source**: Fully open-source.
+- **Group Index and Velocity**: Compute group index and group velocity directly from material objects.
 
 Installation
 ************
@@ -115,6 +116,10 @@ After installing PyOptik and building the material library, you can easily acces
    bk7 = MaterialBank.BK7
    n = bk7.compute_refractive_index(0.55e-6)
    print(f"Refractive index at 0.55 µm: {n}")
+   # Group index and group velocity
+   n_g = bk7.compute_group_index(0.55e-6)
+   v_g = bk7.compute_group_velocity(0.55e-6)
+   print(f"Group index: {n_g:.3f}, group velocity: {v_g:.1f}")
 
 Example
 *******

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ testpaths = [
     "tests/test_tabulated.py",
     "tests/test_usual_materials.py",
     "tests/test_utils.py",
+    "tests/test_group_properties.py",
 ]
 addopts = [
     '-v',

--- a/tests/test_group_properties.py
+++ b/tests/test_group_properties.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+from PyOptik import MaterialBank
+from PyOptik.units import micrometer, meter, ureg
+
+
+def test_group_index_sellmeier():
+    bk7 = MaterialBank.BK7
+    gi = bk7.compute_group_index(0.8 * micrometer)
+    assert gi.magnitude > 1.0
+
+
+def test_group_velocity_tabulated():
+    si = MaterialBank.silicon
+    gv = si.compute_group_velocity(0.6 * micrometer)
+    c = 299792458 * meter / ureg.second
+    assert gv < c
+
+
+def test_group_index_array():
+    water = MaterialBank.water
+    wavelengths = np.linspace(0.5, 0.6, 3) * micrometer
+    gi = water.compute_group_index(wavelengths)
+    assert gi.shape == wavelengths.shape


### PR DESCRIPTION
## Summary
- enable time units for convenience
- add group index and group velocity helpers
- document new utilities in README
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745f0748fc832cac94c4b01577b59e