### PR TITLE
Enhance group index calc & docs

### DIFF
--- a/PyOptik/material/base_class.py
+++ b/PyOptik/material/base_class.py
@@ -112,8 +112,9 @@ class BaseMaterial(object):
             Group refractive index at the specified wavelength, in dimensionless units.
         """
         n = self.compute_refractive_index(wavelength)
-        n_plus = self.compute_refractive_index(wavelength + delta)
-        dn_dlambda = (n_plus - n) / delta
+        n_plus = self.compute_refractive_index(wavelength + delta / 2)
+        n_minus = self.compute_refractive_index(wavelength - delta / 2)
+        dn_dlambda = (n_plus - n_minus) / delta
         return n - wavelength * dn_dlambda
 
     @ensure_units

--- a/PyOptik/material_bank.py
+++ b/PyOptik/material_bank.py
@@ -209,6 +209,15 @@ class _MaterialBank():
         # Print the table using tabulate
         print(tabulate(table_data, headers=headers, tablefmt="grid"))
 
+    @staticmethod
+    def list_available_libraries() -> List[str]:
+        """Return the names of libraries that can be downloaded."""
+        return [
+            os.path.splitext(f)[0]
+            for f in os.listdir(libraries_path)
+            if f.endswith(".yml")
+        ]
+
     @classmethod
     def add_material_to_bank(cls, filename: str, url: str, material_type: MaterialType) -> None:
         """
@@ -333,12 +342,12 @@ class _MaterialBank():
         remove_previous : bool
             If True, removes existing files before downloading new ones.
         """
-        AVAILABLE_LIBRARIES = set([os.path.splitext(f)[0] for f in os.listdir(libraries_path) if f.endswith('.yml')])
+        available = set(self.list_available_libraries())
 
-        libraries_to_download = AVAILABLE_LIBRARIES if library == 'all' else set(numpy.atleast_1d(library))
+        libraries_to_download = available if library == 'all' else set(numpy.atleast_1d(library))
 
         # Ensure the requested library exists
-        assert libraries_to_download.issubset(AVAILABLE_LIBRARIES), f"Library value should be in {AVAILABLE_LIBRARIES}"
+        assert libraries_to_download.issubset(available), f"Library value should be in {available}"
 
         repertoire_file = libraries_path / 'repertoire.yml'
         with open(repertoire_file, 'r') as file:

--- a/docs/examples/README.rst
+++ b/docs/examples/README.rst
@@ -17,6 +17,7 @@ The gallery includes:
   - **Fiber Optic Analysis**: See how PyOptik can be utilized for fiber optics simulations, providing insights into light propagation and mode analysis.
 
   - **Biomedical Imaging Applications**: Discover how PyOptik can be leveraged for imaging purposes, including applications in biomedical optics.
+  - **Group Velocity Analysis**: Learn how to compute and visualise group index and velocity for dispersive materials.
 
 These examples are designed to help users at all levels, whether you are a beginner learning how to use the basic API or an experienced user looking for guidance on more advanced use cases.
 
@@ -30,4 +31,5 @@ Explore the gallery and unlock the potential of PyOptik for your optical simulat
     sellmeier/index.rst
     tabulated/index.rst
     utils/index.rst
+    group_properties/index.rst
 

--- a/docs/examples/group_properties/README.rst
+++ b/docs/examples/group_properties/README.rst
@@ -1,0 +1,6 @@
+Examples: Group Properties
+==========================
+
+This folder showcases how to compute advanced properties derived from the
+refractive index, such as the group index and the group velocity. These metrics
+are useful when analysing pulse propagation in dispersive materials.

--- a/docs/examples/group_properties/plot_group_properties.py
+++ b/docs/examples/group_properties/plot_group_properties.py
@@ -1,0 +1,46 @@
+"""
+Group Index and Velocity of Fused Silica
+=======================================
+
+This example demonstrates how to compute and plot the group index and
+group velocity of fused silica using :mod:`PyOptik`.
+"""
+
+# %%
+import numpy
+import matplotlib.pyplot as plt
+from MPSPlots.styles import mps
+from PyOptik import MaterialBank
+from PyOptik.units import micrometer
+
+# Retrieve the material
+material = MaterialBank.fused_silica
+
+# Compute values over a wavelength range
+wavelengths = numpy.linspace(0.5, 1.6, 200) * micrometer
+n_g = material.compute_group_index(wavelengths)
+v_g = material.compute_group_velocity(wavelengths)
+
+# %% Plot group index and velocity
+with plt.style.context(mps):
+    fig, ax1 = plt.subplots()
+
+ax1.set(
+    xlabel="Wavelength [µm]",
+    ylabel="Group index",
+    title="Fused Silica Group Properties",
+)
+ax1.plot(wavelengths.to(micrometer).magnitude, n_g.magnitude, label="n_g")
+ax1.legend(loc="upper left")
+
+ax2 = ax1.twinx()
+ax2.set(ylabel="Group velocity [m/s]")
+ax2.plot(
+    wavelengths.to(micrometer).magnitude,
+    v_g.to("m/s").magnitude,
+    color="tab:red",
+    label="v_g",
+)
+ax2.legend(loc="upper right")
+
+plt.show()

--- a/docs/examples/tabulated/plot_polyethylene.py
+++ b/docs/examples/tabulated/plot_polyethylene.py
@@ -1,8 +1,8 @@
 """
-Plot the Refractive Index of Optical Material: SF5
-==================================================
+Plot the Refractive Index of Optical Material: Polyethylene
+=========================================================
 
-This module demonstrates the usage of the PyOptik library to calculate and plot the refractive index of the optical material SF5 glass over a specified range of wavelengths.
+This module demonstrates the usage of the PyOptik library to calculate and plot the refractive index of polyethylene over a specified range of wavelengths.
 
 """
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ def reset_mpl(gallery_conf, fname):
 
 
 examples_files = [
-    'utils', 'sellmeier', 'tabulated'
+    'utils', 'sellmeier', 'tabulated', 'group_properties'
 ]
 
 sphinx_gallery_conf = {

--- a/docs/source/gallery/index.rst
+++ b/docs/source/gallery/index.rst
@@ -151,14 +151,14 @@ Contents
 
 .. only:: html
 
-  .. image:: /gallery/tabulated/images/thumb/sphx_glr_plot_sf5_thumb.png
+  .. image:: /gallery/tabulated/images/thumb/sphx_glr_plot_polyethylene_thumb.png
     :alt:
 
-  :ref:`sphx_glr_gallery_tabulated_plot_sf5.py`
+  :ref:`sphx_glr_gallery_tabulated_plot_polyethylene.py`
 
 .. raw:: html
 
-      <div class="sphx-glr-thumbnail-title">Plot the Refractive Index of Optical Material: SF5</div>
+      <div class="sphx-glr-thumbnail-title">Plot the Refractive Index of Optical Material: Polyethylene</div>
     </div>
 
 
@@ -278,6 +278,7 @@ The examples provided here aim to help you leverage these utilities effectively 
    /gallery/sellmeier/index.rst
    /gallery/tabulated/index.rst
    /gallery/utils/index.rst
+   /gallery/group_properties/index.rst
 
 
 


### PR DESCRIPTION
## Summary
- improve accuracy of `compute_group_index`
- expose available library names via `list_available_libraries`
- fix polyethylene example name
- add group properties example and integrate gallery
- update documentation config

## Testing
- `pip install -e .[testing]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b4b786b4832ca27fc0c5c9c0c03c