### PR TITLE
Add material search and CLI options

### DIFF
--- a/PyOptik/__main__.py
+++ b/PyOptik/__main__.py
@@ -17,7 +17,17 @@ def main() -> None:
         action="store_true",
         help="Remove previously downloaded files before downloading",
     )
+    parser.add_argument(
+        "--list-libraries",
+        action="store_true",
+        help="List available library names and exit",
+    )
     args = parser.parse_args()
+
+    if args.list_libraries:
+        for lib in MaterialBank.list_available_libraries():
+            print(lib)
+        return
 
     logging.info("Building material library")
     MaterialBank.build_library(args.library, remove_previous=args.remove_previous)

--- a/PyOptik/material_bank.py
+++ b/PyOptik/material_bank.py
@@ -209,6 +209,34 @@ class _MaterialBank():
         # Print the table using tabulate
         print(tabulate(table_data, headers=headers, tablefmt="grid"))
 
+    def search(self, pattern: str, material_type: Optional[MaterialType] = None) -> List[str]:
+        """Search available materials using a case-insensitive pattern.
+
+        Parameters
+        ----------
+        pattern : str
+            Substring or regular expression to match against material names.
+        material_type : Optional[MaterialType], optional
+            If provided, limit the search to the specified material type.
+
+        Returns
+        -------
+        List[str]
+            List of material names matching the pattern.
+        """
+
+        if material_type is None:
+            names = self.all
+        elif material_type == MaterialType.SELLMEIER:
+            names = self.sellmeier
+        elif material_type == MaterialType.TABULATED:
+            names = self.tabulated
+        else:
+            raise ValueError("Invalid material_type. Use MaterialType.SELLMEIER or MaterialType.TABULATED.")
+
+        regex = re.compile(pattern, re.IGNORECASE)
+        return [name for name in names if regex.search(name)]
+
     @staticmethod
     def list_available_libraries() -> List[str]:
         """Return the names of libraries that can be downloaded."""

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -12,3 +12,13 @@ def test_cli_help():
     assert 'library' in result.stdout
     assert '--remove-previous' in result.stdout
 
+
+def test_cli_list_libraries():
+    result = subprocess.run(
+        [sys.executable, '-m', 'PyOptik', '--list-libraries'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 'minimal' in result.stdout
+

--- a/tests/test_material_bank_extra.py
+++ b/tests/test_material_bank_extra.py
@@ -26,5 +26,22 @@ def test_list_materials(monkeypatch, tmp_path):
     assert sell_list == ["mat1"]
     assert tab_list == ["mat2"]
 
+
+def test_search_materials(monkeypatch, tmp_path):
+    tmp_sell = tmp_path / "sellmeier"
+    tmp_tab = tmp_path / "tabulated"
+    tmp_sell.mkdir()
+    tmp_tab.mkdir()
+    (tmp_sell / "BK7.yml").write_text("test")
+    (tmp_tab / "gold.yml").write_text("test")
+
+    with monkeypatch.context() as m:
+        m.setattr("PyOptik.material_bank.data_path", tmp_path)
+        found_sell = MaterialBank.search("bk")
+        found_tab = MaterialBank.search("gold", material_type=MaterialType.TABULATED)
+
+    assert "BK7" in found_sell
+    assert found_tab == ["gold"]
+
 if __name__ == "__main__":
     pytest.main(["-W error", "-s", __file__])


### PR DESCRIPTION
## Summary
- add a `search` method to `MaterialBank`
- expose `--list-libraries` in CLI
- test new search method
- test CLI new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878480c756c832ca5fc391ae8fbc7f5