### PR TITLE
Add group delay calculations

### DIFF
--- a/PyOptik/material/base_class.py
+++ b/PyOptik/material/base_class.py
@@ -136,3 +136,54 @@ class BaseMaterial(object):
         ng = self.compute_group_index(wavelength)
         c = 299792458 * units.meter / units.second
         return c / ng
+
+    @ensure_units
+    def compute_group_delay(
+        self,
+        wavelength: units.Quantity,
+        length: units.Quantity = 1 * units.meter,
+    ) -> units.Quantity:
+        """Calculate the group delay for a given propagation length.
+
+        Parameters
+        ----------
+        wavelength : units.Quantity
+            Wavelength at which to compute the group delay, in metres.
+        length : units.Quantity, optional
+            Propagation length (default is 1 metre).
+
+        Returns
+        -------
+        units.Quantity
+            Group delay for the specified wavelength and length.
+        """
+        vg = self.compute_group_velocity(wavelength)
+        return length / vg
+
+    @ensure_units
+    def compute_group_delay_dispersion(
+        self,
+        wavelength: units.Quantity,
+        length: units.Quantity = 1 * units.meter,
+        delta: units.Quantity = 1 * units.nanometer,
+    ) -> units.Quantity:
+        """Calculate ``d\u03c4_g/d\u03bb`` for a given propagation length.
+
+        Parameters
+        ----------
+        wavelength : units.Quantity
+            Central wavelength for the computation, in metres.
+        length : units.Quantity, optional
+            Propagation length (default is 1 metre).
+        delta : units.Quantity, optional
+            Wavelength step used for the numerical differentiation (default is
+            1 nanometre).
+
+        Returns
+        -------
+        units.Quantity
+            Group delay dispersion evaluated at ``wavelength``.
+        """
+        gd_plus = self.compute_group_delay(wavelength + delta / 2, length)
+        gd_minus = self.compute_group_delay(wavelength - delta / 2, length)
+        return (gd_plus - gd_minus) / delta

--- a/tests/test_group_properties.py
+++ b/tests/test_group_properties.py
@@ -23,5 +23,18 @@ def test_group_index_array():
     gi = water.compute_group_index(wavelengths)
     assert gi.shape == wavelengths.shape
 
+
+def test_group_delay():
+    bk7 = MaterialBank.BK7
+    gd = bk7.compute_group_delay(0.8 * micrometer, length=1 * meter)
+    assert gd.magnitude > 0.0
+
+
+def test_group_delay_dispersion():
+    si = MaterialBank.silicon
+    gdd = si.compute_group_delay_dispersion(0.6 * micrometer)
+    assert np.isfinite(gdd.magnitude)
+
+
 if __name__ == "__main__":
     pytest.main(["-W error", "-s", __file__])


### PR DESCRIPTION
## Summary
- add methods to compute group delay and dispersion
- test group delay APIs

## Testing
- `flake8 PyOptik/material/base_class.py`
- `flake8 tests/test_group_properties.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68784e6643c8832c86cb4ef334f01d71