### PR TITLE
Add additional Sphinx-Gallery examples

### DIFF
--- a/docs/examples/sellmeier/plot_compare_glasses.py
+++ b/docs/examples/sellmeier/plot_compare_glasses.py
@@ -1,0 +1,41 @@
+"""
+Compare the Refractive Index of BK7 and Fused Silica
+====================================================
+
+This example compares two common optical glasses available in
+:class:`~PyOptik.material_bank.MaterialBank`. It computes and plots the
+refractive index of BK7 and fused silica over the visible to near
+infrared wavelength range.
+"""
+
+# %%
+import numpy
+import matplotlib.pyplot as plt
+from MPSPlots.styles import mps
+from PyOptik import MaterialBank
+from PyOptik.units import micrometer
+
+# Retrieve materials
+bk7 = MaterialBank.BK7
+silica = MaterialBank.fused_silica
+
+# Prepare wavelength range
+wavelengths = numpy.linspace(0.4, 1.6, 300) * micrometer
+
+n_bk7 = bk7.compute_refractive_index(wavelengths)
+n_silica = silica.compute_refractive_index(wavelengths)
+
+# %% Plot comparison
+with plt.style.context(mps):
+    fig, ax = plt.subplots()
+
+ax.set(
+    title="BK7 vs Fused Silica",
+    xlabel="Wavelength [µm]",
+    ylabel="Refractive index",
+)
+ax.plot(wavelengths.to(micrometer).magnitude, n_bk7.real, label="BK7")
+ax.plot(wavelengths.to(micrometer).magnitude, n_silica.real, label="Fused Silica")
+ax.legend()
+
+plt.show()

--- a/docs/examples/tabulated/plot_silicon_nk.py
+++ b/docs/examples/tabulated/plot_silicon_nk.py
@@ -1,0 +1,39 @@
+"""
+Plot the Refractive Index and Absorption of Silicon
+===================================================
+
+This example uses :mod:`PyOptik` to visualise both the real and
+imaginary parts of the refractive index of silicon over a typical
+infrared wavelength range.
+"""
+
+# %%
+import numpy
+import matplotlib.pyplot as plt
+from MPSPlots.styles import mps
+from PyOptik import MaterialBank
+from PyOptik.units import micrometer
+
+material = MaterialBank.silicon
+
+wavelengths = numpy.linspace(0.3, 1.1, 300) * micrometer
+index = material.compute_refractive_index(wavelengths)
+
+# %% Plot n and k
+with plt.style.context(mps):
+    fig, ax1 = plt.subplots()
+
+ax1.set(
+    title="Silicon Refractive Index and Absorption",
+    xlabel="Wavelength [µm]",
+    ylabel="n",
+)
+ax1.plot(wavelengths.to(micrometer).magnitude, index.real, label="n", color="tab:blue")
+ax1.legend(loc="upper left")
+
+ax2 = ax1.twinx()
+ax2.set(ylabel="k")
+ax2.plot(wavelengths.to(micrometer).magnitude, index.imag, color="tab:red", label="k")
+ax2.legend(loc="upper right")
+
+plt.show()

--- a/docs/examples/utils/search_materials.py
+++ b/docs/examples/utils/search_materials.py
@@ -1,0 +1,23 @@
+"""
+Searching the MaterialBank
+==========================
+
+This example shows how to locate materials using patterns with
+:func:`~PyOptik.material_bank.MaterialBank.search` and then load a
+material for analysis.
+"""
+
+# %%
+from PyOptik import MaterialBank
+from PyOptik.units import micrometer
+
+# Find materials containing the substring 'si'
+materials = MaterialBank.search("si")
+print("Matches:")
+for name in materials:
+    print("-", name)
+
+# Use the first match
+material = MaterialBank.get(materials[0])
+print("\nRefractive index at 1 µm:")
+print(material.compute_refractive_index(1 * micrometer))


### PR DESCRIPTION
## Summary
- add comparison of BK7 and fused silica
- add silicon n/k example
- add MaterialBank search usage example

## Testing
- `pip install -e .[testing]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784fe7c5fc832c8f4bc08e2111d15b